### PR TITLE
build->host

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - jupyter nbextension install --sys-prefix --py rise
 
 requirements:
-  build:
+  host:
     - python
     - pip >=10.0.1
     - notebook >=5.5.0


### PR DESCRIPTION
This is only necessary for cross-compiling (e.g. packaging for win-32 on win-64)